### PR TITLE
Enable reusable SVG groups

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -161,9 +161,11 @@ Sets the radius for points (rendered as tiny circles) in the SVG output. Default
 
 
 ## beginSvgGroup
-Begins a new user-defined grouping of SVG elements.
-Optionally associates a group name to the SVG group.
-Be sure to call `endSvgGroup()` later or the SVG file will report errors.
+Begins a user-defined grouping of SVG elements. If a group name is
+provided, later calls with the same name append new elements to that
+group even if it has been closed with `endSvgGroup()`. Calling the
+function without a name inserts an unnamed `<g>` element at the current
+drawing position. Always pair this with `endSvgGroup()`.
 
 #### Parameters
 *   `gname` **[string][27]?** Optional group name used as an ID for the SVG group.
@@ -171,7 +173,10 @@ Be sure to call `endSvgGroup()` later or the SVG file will report errors.
 
 
 ## endSvgGroup
-Ends the current user-defined group of SVG elements.
+Ends the current user-defined group of SVG elements. When closing a
+named group this simply stops tagging subsequent commands with that
+group's ID. When closing an unnamed group it writes the closing `</g>`
+tag into the SVG output.
 
 
 

--- a/documentation.md
+++ b/documentation.md
@@ -162,10 +162,11 @@ Sets the radius for points (rendered as tiny circles) in the SVG output. Default
 
 ## beginSvgGroup
 Begins a user-defined grouping of SVG elements. If a group name is
-provided, later calls with the same name append new elements to that
-group even if it has been closed with `endSvgGroup()`. Calling the
-function without a name inserts an unnamed `<g>` element at the current
-drawing position. Always pair this with `endSvgGroup()`.
+provided, later calls with the same name append new elements to the
+existing group even after calling `endSvgGroup()`. Named groups may be
+nested inside unnamed groups. Calling the function without a name
+inserts an anonymous `<g>` element at the current drawing position.
+Always pair this with `endSvgGroup()`.
 
 #### Parameters
 *   `gname` **[string][27]?** Optional group name used as an ID for the SVG group.
@@ -173,10 +174,11 @@ drawing position. Always pair this with `endSvgGroup()`.
 
 
 ## endSvgGroup
-Ends the current user-defined group of SVG elements. When closing a
-named group this simply stops tagging subsequent commands with that
-group's ID. When closing an unnamed group it writes the closing `</g>`
-tag into the SVG output.
+Ends the most recently started SVG group. For named groups this
+releases the current association but does not finalize the group, so
+later calls to `beginSvgGroup` with the same name continue to append to
+it. When closing an unnamed group the corresponding `</g>` tag is
+written to the SVG output.
 
 
 

--- a/lib/p5.plotSvg.js
+++ b/lib/p5.plotSvg.js
@@ -47,7 +47,9 @@
   let _p5Instance; 
   let _p5PixelDensity = 1; 
   let _commands = [];
-  let _svgGroupLevel = 0; 
+  let _svgGroupLevel = 0;
+  let _currentSvgGroupName = null;
+  let _svgGroupOrder = [];
   let _vertexStack = []; // Temp stack for polyline/polygon vertices 
   let _shapeMode = "simple"; // Track mode: "simple" or "complex"
   let _shapeKind = "poly";
@@ -275,7 +277,7 @@
           console.warn("arc() detail is currently unsupported in SVG output.");
         }
         let transformMatrix = captureCurrentTransformMatrix();
-        _commands.push({ type: 'arc', x, y, w, h, start, stop, mode, transformMatrix });
+        _commands.push({ type: 'arc', x, y, w, h, start, stop, mode, transformMatrix, gname: _currentSvgGroupName });
       }
       _originalArcFunc.apply(this, arguments);
     };
@@ -293,7 +295,7 @@
     _p5Instance.bezier = function(x1, y1, x2, y2, x3, y3, x4, y4) {
       if (_bRecordingSvg) {
         let transformMatrix = captureCurrentTransformMatrix();
-        _commands.push({ type: 'bezier', x1, y1, x2, y2, x3, y3, x4, y4, transformMatrix });
+        _commands.push({ type: 'bezier', x1, y1, x2, y2, x3, y3, x4, y4, transformMatrix, gname: _currentSvgGroupName });
       }
       _originalBezierFunc.apply(this, arguments);
     };
@@ -315,20 +317,20 @@
         let transformMatrix = captureCurrentTransformMatrix();
         
         if (_p5Instance._renderer._ellipseMode === 'center'){
-          _commands.push({ type: 'circle', x, y, d, transformMatrix });
+          _commands.push({ type: 'circle', x, y, d, transformMatrix, gname: _currentSvgGroupName });
         } else if (_p5Instance._renderer._ellipseMode === 'corner'){
           x += d/2;
           y += d/2;
-          _commands.push({ type: 'circle', x, y, d, transformMatrix });
+          _commands.push({ type: 'circle', x, y, d, transformMatrix, gname: _currentSvgGroupName });
         } else if (_p5Instance._renderer._ellipseMode === 'radius'){
           d *= 2;
-          _commands.push({ type: 'circle', x, y, d, transformMatrix });
+          _commands.push({ type: 'circle', x, y, d, transformMatrix, gname: _currentSvgGroupName });
         } else if (_p5Instance._renderer._ellipseMode === 'corners'){
           let w = d - x; 
           let h = d - y;
           x += w/2;
           y += h/2;
-          _commands.push({ type: 'ellipse', x, y, w, h, transformMatrix });
+          _commands.push({ type: 'ellipse', x, y, w, h, transformMatrix, gname: _currentSvgGroupName });
         }
       }
       
@@ -358,7 +360,7 @@
         x3 = adjX3; y3 = adjY3;
         x4 = adjX4; y4 = adjY4;
         let transformMatrix = captureCurrentTransformMatrix();
-        _commands.push({ type: 'curve', x1, y1, x2, y2, x3, y3, x4, y4, transformMatrix });
+        _commands.push({ type: 'curve', x1, y1, x2, y2, x3, y3, x4, y4, transformMatrix, gname: _currentSvgGroupName });
       }
       _originalCurveFunc.apply(this, arguments);
     };
@@ -403,7 +405,7 @@
           y += h/2;
         }
         let transformMatrix = captureCurrentTransformMatrix();
-        _commands.push({ type: 'ellipse', x, y, w, h, transformMatrix });
+        _commands.push({ type: 'ellipse', x, y, w, h, transformMatrix, gname: _currentSvgGroupName });
       }
       _originalEllipseFunc.apply(this, arguments);
     };
@@ -421,7 +423,7 @@
     _p5Instance.line = function(x1, y1, x2, y2) {
       if (_bRecordingSvg) { 
         let transformMatrix = captureCurrentTransformMatrix();
-        _commands.push({ type: 'line', x1, y1, x2, y2, transformMatrix });
+        _commands.push({ type: 'line', x1, y1, x2, y2, transformMatrix, gname: _currentSvgGroupName });
       }
       _originalLineFunc.apply(this, arguments);
     };
@@ -439,7 +441,7 @@
     _p5Instance.point = function(x, y) {
       if (_bRecordingSvg) {
         let transformMatrix = captureCurrentTransformMatrix();
-        _commands.push({ type: 'point', x, y, radius: _svgPointRadius, transformMatrix });
+        _commands.push({ type: 'point', x, y, radius: _svgPointRadius, transformMatrix, gname: _currentSvgGroupName });
       }
       _originalPointFunc.apply(this, arguments);
     };
@@ -457,7 +459,7 @@
     _p5Instance.quad = function(x1, y1, x2, y2, x3, y3, x4, y4) {
       if (_bRecordingSvg) { 
         let transformMatrix = captureCurrentTransformMatrix();
-        _commands.push({ type: 'quad', x1, y1, x2, y2, x3, y3, x4, y4, transformMatrix });
+        _commands.push({ type: 'quad', x1, y1, x2, y2, x3, y3, x4, y4, transformMatrix, gname: _currentSvgGroupName });
       }
       _originalQuadFunc.apply(this, arguments);
     };
@@ -503,11 +505,11 @@
         let transformMatrix = captureCurrentTransformMatrix();
         // Check for corner radii
         if (arguments.length === 5) { // Single corner radius
-          _commands.push({ type: 'rect', x, y, w, h, tl, transformMatrix });
+          _commands.push({ type: 'rect', x, y, w, h, tl, transformMatrix, gname: _currentSvgGroupName });
         } else if (arguments.length === 8) { // Individual corner radii
-          _commands.push({ type: 'rect', x, y, w, h, tl,tr,br,bl, transformMatrix });
+          _commands.push({ type: 'rect', x, y, w, h, tl,tr,br,bl, transformMatrix, gname: _currentSvgGroupName });
         } else { // Standard rectangle
-          _commands.push({ type: 'rect', x, y, w, h, transformMatrix });
+          _commands.push({ type: 'rect', x, y, w, h, transformMatrix, gname: _currentSvgGroupName });
         }
       }
       _originalRectFunc.apply(this, arguments);
@@ -554,11 +556,11 @@
         
         let transformMatrix = captureCurrentTransformMatrix();
         if (arguments.length === 3) { // standard square
-          _commands.push({ type: 'rect', x, y, w, h, transformMatrix });
+          _commands.push({ type: 'rect', x, y, w, h, transformMatrix, gname: _currentSvgGroupName });
         } else if (arguments.length === 4) { // rounded square
-          _commands.push({ type: 'rect', x, y, w, h, tl, transformMatrix });
+          _commands.push({ type: 'rect', x, y, w, h, tl, transformMatrix, gname: _currentSvgGroupName });
         } else if (arguments.length === 7) {
-          _commands.push({ type: 'rect', x, y, w, h, tl,tr,br,bl, transformMatrix });
+          _commands.push({ type: 'rect', x, y, w, h, tl,tr,br,bl, transformMatrix, gname: _currentSvgGroupName });
         }
       }
       _originalSquareFunc.apply(this, arguments);
@@ -577,7 +579,7 @@
     _p5Instance.triangle = function(x1, y1, x2, y2, x3, y3) {
       if (_bRecordingSvg) {
         let transformMatrix = captureCurrentTransformMatrix();
-        _commands.push({ type: 'triangle', x1, y1, x2, y2, x3, y3, transformMatrix });
+        _commands.push({ type: 'triangle', x1, y1, x2, y2, x3, y3, transformMatrix, gname: _currentSvgGroupName });
       }
       _originalTriangleFunc.apply(this, arguments);
     };
@@ -750,25 +752,25 @@
         // Dispatch based on `_shapeKind`
         switch (_shapeKind) {
           case 'points':
-            _commands.push({ type: 'points', vertices: [..._vertexStack], transformMatrix });
+            _commands.push({ type: 'points', vertices: [..._vertexStack], transformMatrix, gname: _currentSvgGroupName });
             break;
           case _p5Instance.LINES:
-            _commands.push({ type: 'lines', vertices: [..._vertexStack], transformMatrix });
+            _commands.push({ type: 'lines', vertices: [..._vertexStack], transformMatrix, gname: _currentSvgGroupName });
             break;
           case _p5Instance.TRIANGLES:
-            _commands.push({ type: 'triangles', vertices: [..._vertexStack], transformMatrix });
+            _commands.push({ type: 'triangles', vertices: [..._vertexStack], transformMatrix, gname: _currentSvgGroupName });
             break;
           case _p5Instance.TRIANGLE_FAN:
-            _commands.push({ type: 'triangle_fan', vertices: [..._vertexStack], transformMatrix });
+            _commands.push({ type: 'triangle_fan', vertices: [..._vertexStack], transformMatrix, gname: _currentSvgGroupName });
             break;
           case _p5Instance.TRIANGLE_STRIP:
-            _commands.push({ type: 'triangle_strip', vertices: [..._vertexStack], transformMatrix });
+            _commands.push({ type: 'triangle_strip', vertices: [..._vertexStack], transformMatrix, gname: _currentSvgGroupName });
             break;
           case _p5Instance.QUADS:
-            _commands.push({ type: 'quads', vertices: [..._vertexStack], transformMatrix });
+            _commands.push({ type: 'quads', vertices: [..._vertexStack], transformMatrix, gname: _currentSvgGroupName });
             break;
           case _p5Instance.QUAD_STRIP:
-            _commands.push({ type: 'quad_strip', vertices: [..._vertexStack], transformMatrix });
+            _commands.push({ type: 'quad_strip', vertices: [..._vertexStack], transformMatrix, gname: _currentSvgGroupName });
             break;
             
           case 'poly': 
@@ -780,14 +782,16 @@
                 type: 'polyline',
                 vertices: [..._vertexStack],
                 closed: isClosed,
-                transformMatrix
+                transformMatrix,
+                gname: _currentSvgGroupName
               });
             } else {
               _commands.push({
                 type: 'path',
                 segments: [..._vertexStack],
                 closed: isClosed,
-                transformMatrix
+                transformMatrix,
+                gname: _currentSvgGroupName
               });
             }
             break;
@@ -814,7 +818,7 @@
       if (_bRecordingSvg) {
         if (description && description.trim().length > 0){
           // Push a command to the stack for generating an SVG `desc` element
-          _commands.push({ type: 'description', text: description });
+          _commands.push({ type: 'description', text: description, gname: _currentSvgGroupName });
         }
       }
       _originalDescribeFunc.apply(this, arguments);
@@ -833,7 +837,7 @@
     _bTransformsExist = true; 
     _p5Instance.push = function() {
       if (_bRecordingSvg) {
-        _commands.push({ type: 'push' });
+        _commands.push({ type: 'push', gname: _currentSvgGroupName });
       }
       _originalPushFunc.apply(this, arguments);
     };
@@ -851,7 +855,7 @@
     _bTransformsExist = true; 
     _p5Instance.pop = function() {
       if (_bRecordingSvg) {
-        _commands.push({ type: 'pop' });
+        _commands.push({ type: 'pop', gname: _currentSvgGroupName });
       }
       _originalPopFunc.apply(this, arguments);
     };
@@ -869,7 +873,7 @@
     _bTransformsExist = true; 
     _p5Instance.scale = function(sx, sy) {
       if (_bRecordingSvg) {
-        _commands.push({ type: 'scale', sx, sy: sy || sx });
+        _commands.push({ type: 'scale', sx, sy: sy || sx, gname: _currentSvgGroupName });
       }
       _originalScaleFunc.apply(this, arguments);
     };
@@ -887,7 +891,7 @@
     _bTransformsExist = true; 
     _p5Instance.translate = function(tx, ty) {
       if (_bRecordingSvg) {
-        _commands.push({ type: 'translate', tx, ty });
+        _commands.push({ type: 'translate', tx, ty, gname: _currentSvgGroupName });
       }
       _originalTranslateFunc.apply(this, arguments);
     };
@@ -905,7 +909,7 @@
     _bTransformsExist = true; 
     _p5Instance.rotate = function(angle) {
       if (_bRecordingSvg) {
-        _commands.push({ type: 'rotate', angle });
+        _commands.push({ type: 'rotate', angle, gname: _currentSvgGroupName });
       }
       _originalRotateFunc.apply(this, arguments);
     };
@@ -923,7 +927,7 @@
     _bTransformsExist = true; 
     _p5Instance.shearX = function(angle) {
       if (_bRecordingSvg) {
-        _commands.push({ type: 'shearx', angle });
+        _commands.push({ type: 'shearx', angle, gname: _currentSvgGroupName });
       }
       _originalShearXFunc.apply(this, arguments);
     };
@@ -941,7 +945,7 @@
     _bTransformsExist = true; 
     _p5Instance.shearY = function(angle) {
       if (_bRecordingSvg) {
-        _commands.push({ type: 'sheary', angle });
+        _commands.push({ type: 'sheary', angle, gname: _currentSvgGroupName });
       }
       _originalShearYFunc.apply(this, arguments);
     };
@@ -978,8 +982,9 @@
         let transformMatrix = captureCurrentTransformMatrix();
 
         // Push text command with properties
-        _commands.push({ type: 'text', content, x, y, 
-                        font, fontSize, alignX, alignY, style, leading, ascent, descent, transformMatrix });
+        _commands.push({ type: 'text', content, x, y,
+                        font, fontSize, alignX, alignY, style, leading, ascent, descent, transformMatrix,
+                        gname: _currentSvgGroupName });
       }
       _originalTextFunc.apply(this, arguments);
     };
@@ -1030,8 +1035,56 @@
     svgContent += `<g vector-effect="non-scaling-stroke">\n`;
     _svgGroupLevel++;
 
-    let transformGroupStack = []; 
+    const defaultKey = '__default__';
+    let grouped = { [defaultKey]: [] };
     for (let cmd of _commands) {
+      let g = cmd.gname || defaultKey;
+      if (!grouped[g]) grouped[g] = [];
+      grouped[g].push(cmd);
+    }
+
+    const groupOrder = [defaultKey, ..._svgGroupOrder.filter(g => grouped[g])];
+
+    for (let gname of groupOrder) {
+      if (gname !== defaultKey) {
+        svgContent += getIndentStr();
+        svgContent += `<g id="${gname}">\n`;
+        _svgGroupLevel++;
+      }
+
+      svgContent += commandsToSvg(grouped[gname]);
+
+      if (gname !== defaultKey) {
+        _svgGroupLevel--;
+        svgContent += getIndentStr();
+        svgContent += `</g>\n`;
+      }
+    }
+
+    svgContent += `</g>\n`; // Close the `non-scaling-stroke` group
+    svgContent += `</svg>`;
+
+    const blob = new Blob([svgContent], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = _svgFilename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+
+    svgContent = "";
+    _commands = [];
+    _vertexStack = [];
+    _svgGroupOrder = [];
+    _currentSvgGroupName = null;
+  }
+
+  function commandsToSvg(cmdArray){
+    let svgContent = "";
+    let transformGroupStack = [];
+    for (let cmd of cmdArray) {
 
       if (cmd.type === 'push' ||
           cmd.type === 'pop' ||
@@ -1143,36 +1196,21 @@
       } 
     }
     
-    // Close any remaining groups
-    if (!_bFlattenTransforms) {
-      while (transformGroupStack.length > 0) {
-        while (transformGroupStack[transformGroupStack.length - 1] > 0){
-          transformGroupStack[transformGroupStack.length - 1]--; 
-          _svgGroupLevel = Math.max(0, _svgGroupLevel - 1);
-          svgContent += getIndentStr();
-          svgContent += `</g>\n`;
+      // Close any remaining groups
+      if (!_bFlattenTransforms) {
+        while (transformGroupStack.length > 0) {
+          while (transformGroupStack[transformGroupStack.length - 1] > 0){
+            transformGroupStack[transformGroupStack.length - 1]--;
+            _svgGroupLevel = Math.max(0, _svgGroupLevel - 1);
+            svgContent += getIndentStr();
+            svgContent += `</g>\n`;
+          }
+          transformGroupStack.pop();
         }
-        transformGroupStack.pop();
       }
-    }
-    
-    svgContent += `</g>\n`; // Close the `non-scaling-stroke` group
-    svgContent += `</svg>`;
 
-    const blob = new Blob([svgContent], { type: 'image/svg+xml' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = _svgFilename;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-    
-    svgContent = ""; 
-    _commands = [];
-    _vertexStack = []; 
-  }
+      return svgContent;
+    }
 
 
   /**
@@ -1844,22 +1882,39 @@
 
 
   /**
-   * Begins a new user-defined grouping of SVG elements.
-   * Optionally associates a group name to the SVG group.
-   * Be sure to call `endSvgGroup()` later or the SVG file will report errors.
+   * Begins or switches the current user-defined SVG group.
+   * If a group name is provided, subsequent drawing commands
+   * are associated with that group. Calling {@link endSvgGroup}
+   * resets the current group back to `null`. The same group name
+   * can be reactivated multiple times; all commands recorded while
+   * that group is active will be merged into a single SVG group.
+   *
    * @param {string} [gname] - Optional group name used as an ID for the SVG group.
    */
   p5plotSvg.beginSvgGroup = function(gname) {
-    _commands.push({ type: 'beginGroup', gname });
+    if (typeof gname === 'string') {
+      _currentSvgGroupName = gname;
+      if (!_svgGroupOrder.includes(_currentSvgGroupName)) {
+        _svgGroupOrder.push(_currentSvgGroupName);
+      }
+    } else {
+      _commands.push({ type: 'beginGroup' });
+      _currentSvgGroupName = null;
+    }
   }
 
 
   /**
    * Ends the current user-defined group of SVG elements.
+   * Subsequent commands will not belong to any user group
+   * until {@link beginSvgGroup} is called again.
    */
   p5plotSvg.endSvgGroup = function() {
-    // Push an 'endGroup' command to signify closing the group
-    _commands.push({ type: 'endGroup' });
+    if (_currentSvgGroupName) {
+      _currentSvgGroupName = null;
+    } else {
+      _commands.push({ type: 'endGroup' });
+    }
   }
 
 
@@ -2577,7 +2632,7 @@
         }
 
         // Add a command to the stack to update the stroke color
-        _commands.push({ type: 'stroke', color: scol });
+        _commands.push({ type: 'stroke', color: scol, gname: _currentSvgGroupName });
       }
       // Call the original p5.js `stroke` function with all arguments
       _originalStrokeFunc.apply(this, args);

--- a/lib/p5.plotSvg.js
+++ b/lib/p5.plotSvg.js
@@ -1035,31 +1035,62 @@
     svgContent += `<g vector-effect="non-scaling-stroke">\n`;
     _svgGroupLevel++;
 
-    const defaultKey = '__default__';
-    let grouped = { [defaultKey]: [] };
+    const rootNode = { gname: null, parent: null, commands: [], children: [], namedChildren: {} };
+    let currentNode = rootNode;
+    const stack = [rootNode];
+
     for (let cmd of _commands) {
-      let g = cmd.gname || defaultKey;
-      if (!grouped[g]) grouped[g] = [];
-      grouped[g].push(cmd);
+      if (cmd.type === 'beginGroup') {
+        let node;
+        if (cmd.gname) {
+          if (!currentNode.namedChildren[cmd.gname]) {
+            node = { gname: cmd.gname, parent: currentNode, commands: [], children: [], namedChildren: {} };
+            currentNode.namedChildren[cmd.gname] = node;
+            currentNode.children.push(node);
+          } else {
+            node = currentNode.namedChildren[cmd.gname];
+          }
+        } else {
+          node = { gname: null, parent: currentNode, commands: [], children: [], namedChildren: {} };
+          currentNode.children.push(node);
+        }
+        currentNode = node;
+        stack.push(node);
+      } else if (cmd.type === 'endGroup') {
+        stack.pop();
+        currentNode = stack[stack.length - 1];
+      } else {
+        currentNode.commands.push(cmd);
+      }
     }
 
-    const groupOrder = [defaultKey, ..._svgGroupOrder.filter(g => grouped[g])];
-
-    for (let gname of groupOrder) {
-      if (gname !== defaultKey) {
-        svgContent += getIndentStr();
-        svgContent += `<g id="${gname}">\n`;
+    function renderNode(node) {
+      let str = '';
+      if (node !== rootNode) {
+        str += getIndentStr();
+        if (node.gname) {
+          str += `<g id="${node.gname}">\n`;
+        } else {
+          str += `<g>\n`;
+        }
         _svgGroupLevel++;
       }
 
-      svgContent += commandsToSvg(grouped[gname]);
+      str += commandsToSvg(node.commands);
 
-      if (gname !== defaultKey) {
-        _svgGroupLevel--;
-        svgContent += getIndentStr();
-        svgContent += `</g>\n`;
+      for (let child of node.children) {
+        str += renderNode(child);
       }
+
+      if (node !== rootNode) {
+        _svgGroupLevel--;
+        str += getIndentStr();
+        str += `</g>\n`;
+      }
+      return str;
     }
+
+    svgContent += renderNode(rootNode);
 
     svgContent += `</g>\n`; // Close the `non-scaling-stroke` group
     svgContent += `</svg>`;
@@ -1892,13 +1923,13 @@
    * @param {string} [gname] - Optional group name used as an ID for the SVG group.
    */
   p5plotSvg.beginSvgGroup = function(gname) {
+    _commands.push({ type: 'beginGroup', gname });
     if (typeof gname === 'string') {
       _currentSvgGroupName = gname;
       if (!_svgGroupOrder.includes(_currentSvgGroupName)) {
         _svgGroupOrder.push(_currentSvgGroupName);
       }
     } else {
-      _commands.push({ type: 'beginGroup' });
       _currentSvgGroupName = null;
     }
   }
@@ -1910,11 +1941,8 @@
    * until {@link beginSvgGroup} is called again.
    */
   p5plotSvg.endSvgGroup = function() {
-    if (_currentSvgGroupName) {
-      _currentSvgGroupName = null;
-    } else {
-      _commands.push({ type: 'endGroup' });
-    }
+    _commands.push({ type: 'endGroup' });
+    _currentSvgGroupName = null;
   }
 
 


### PR DESCRIPTION
## Summary
- allow anonymous groups to behave as before
- update beginSvgGroup and endSvgGroup logic for unnamed groups
- reset group state after exporting
- clarify documentation for beginSvgGroup and endSvgGroup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851e2479d58832fb52f3fa5cf40bb04